### PR TITLE
Improve JSON error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,112 @@
+# Stone Knowledgebase Manager
+
+Dieses Programm hilft dabei, eine Knowledgebase im CSV-Format zu pflegen.
+Es richtet sich speziell an die Nutzung mit einem Vapi Voice Agent.
+
+## Datenstruktur
+
+Alle Fragen und Antworten werden in einer einzigen Datei `knowledgebase.csv`
+gespeichert. Die Tabelle besitzt folgende Spalten:
+
+```
+category, faq_question, answer_text, stone_type,
+product_form, product_size, eigenschaft, anwendung
+```
+`product_size` sollte immer die passende Einheit enthalten, beispielsweise
+`8/16 mm` oder `30 cm`.
+
+`category` unterscheidet `Produkt`, `Lieferung`, `Konstruktion` und
+`Sonstiges`. Die übrigen Felder können leer bleiben,
+wenn sie nicht zum jeweiligen Eintrag passen.
+Beim Speichern überprüft eine kleine Pydantic-Datenklasse die Eingaben und
+ergänzt fehlende Einheiten bei `product_size` automatisch.
+
+## Verwendung
+
+1. Python 3.11 oder neuer installieren.
+2. Abhängigkeiten installieren:
+   ```bash
+   pip install -r requirements.txt
+   ```
+   Die Datei benötigt `openai>=1.0`. Das Programm verwendet bereits die
+   neue clientbasierte Schnittstelle der Bibliothek. Zusätzlich werden
+   `numpy`, `pydantic` und `ttkbootstrap` genutzt.
+3. Programm starten (benötigt eine grafische Oberfläche):
+   ```bash
+   python kb_manager.py
+   ```
+   In einer Kopf-losen Umgebung kann ein virtuelles Display wie
+   `Xvfb` verwendet werden.
+4. Nach dem Start werden alle bestehenden Einträge rechts im Fenster angezeigt
+   und lassen sich durchscrollen oder filtern. Eine Suchleiste über der Tabelle
+   ermöglicht das schnelle Auffinden von Fragen.
+5. Die Felder ausfüllen und auf **Ähnliche Fragen anzeigen** klicken, um
+   vorhandene oder ähnliche FAQ-Einträge zu suchen. Die Tabelle scrollt
+   automatisch zum besten Treffer.
+6. Mit **Speichern** wird der Eintrag in `knowledgebase.csv` angehängt oder –
+   wenn vorher ein Datensatz geladen wurde – aktualisiert.
+7. Über **Eintrag laden** kann eine markierte Zeile zum Bearbeiten in das
+   Formular übernommen werden.
+8. Mit **Eintrag löschen** wird die ausgewählte Zeile dauerhaft entfernt. Über
+   **Rückgängig Löschen** lässt sich der letzte gelöschte Datensatz wiederherstellen.
+9. **Neu** leert das Formular ohne zu speichern.
+10. Durch einen Doppelklick auf eine Tabellenzeile wird der Eintrag direkt zum Bearbeiten geladen.
+11. Ein Klick auf einen Spaltenkopf sortiert die Tabelle.
+12. Unten links zeigt das Fenster die aktuelle Versionsnummer an.
+13. Ein Dark-Mode-Button wechselt zwischen hellem und dunklem Stil.
+14. Rechtsklick-Menüs bieten schnellen Zugriff auf Laden, Speichern und
+    Löschen. Ein globaler Hotkey **Strg+S** speichert den aktuellen Eintrag.
+15. Alle Felder sind dauerhaft sichtbar in der Reihenfolge der CSV-Spalten.
+    Das Programm verwendet überall die Schriftart Aptos in Größe 12 pt.
+16. Beim Tippen in die Filterzeile startet automatisch eine Live-Suche. Ein
+    Fortschrittsbalken erscheint, wenn sie länger dauert.
+17. Tooltips erklären die Eingabefelder. Die Texte liegen in
+    `ui_tooltips.json` und lassen sich leicht anpassen.
+
+Nach Installation der Abhängigkeiten können automatisierte Tests mit
+`pytest` ausgeführt werden. Zusätzlich sorgt `flake8` für einheitlichen
+Code-Stil:
+
+```bash
+pytest
+flake8
+```
+
+## KI-Unterstützung
+
+Neben dem manuellen Einpflegen kann das Programm aus beliebigem Text neue
+FAQ-Vorschläge generieren. Dazu muss einmalig ein OpenAI-API-Key hinterlegt
+werden. Der Key kann per Umgebungsvariable `OPENAI_API_KEY` oder nach
+Programmstart über den Button **API-Key eingeben** gesetzt werden.
+
+Im Feld **Text für KI-Vorschläge** kann beliebiger Text eingefügt werden.
+Mit **Vorschläge generieren** analysiert die KI den Inhalt und erstellt immer
+bis zu fünf passende FAQ-Einträge. Fehlen im Text wichtige Angaben, erfindet
+die KI eigenständig sinnvolle Fragen und lässt unklare Felder leer.
+
+Für die Suche nach ähnlichen Fragen nutzt das Programm OpenAI-Embeddings
+anstelle klassischer TF-IDF-Vektoren. Dadurch werden auch semantisch passende
+Einträge gefunden.
+
+Alle generierten Vorschläge sammeln sich in einer Liste unterhalb des
+Formulars. Ein Doppelklick übernimmt einen Vorschlag in die Eingabefelder und
+entfernt ihn aus der Liste. Nicht benötigte Elemente können über
+**Vorschlag löschen** entfernt werden. Neue Aufrufe von
+**Vorschläge generieren** fügen weitere Einträge an, die bestehenden bleiben
+erhalten, bis sie geladen, gespeichert oder gelöscht wurden.
+
+Wird die Datei nicht gefunden, wird sie automatisch mit der passenden
+Spaltenstruktur erstellt.
+
+## Erstellung einer Windows-Exe
+
+Nach Installation der Abhängigkeiten kann mit [PyInstaller](https://pyinstaller.org/) eine
+executable erstellt werden:
+
+```bash
+pip install pyinstaller
+pyinstaller --onefile kb_manager.py
+```
+
+Die fertige `kb_manager.exe` liegt anschließend im Ordner `dist` und
+kann auf einem Windows 11 Rechner ausgeführt werden.

--- a/kb_manager.py
+++ b/kb_manager.py
@@ -1,0 +1,877 @@
+import os
+import sys
+import textwrap
+import pandas as pd
+import numpy as np
+import json
+from pydantic import BaseModel, validator
+from openai import OpenAI
+from language_tool_python import LanguageTool
+from tkinter import (
+    Label,
+    Entry,
+    Text,
+    Listbox,
+    Scrollbar,
+    END,
+    Menu,
+    Toplevel,
+    Frame,
+    StringVar,
+    filedialog,
+)
+from tkinter import ttk, simpledialog
+import subprocess
+import ttkbootstrap as tb
+from ttkbootstrap.toast import ToastNotification
+
+try:
+    VERSION = os.environ["PR_NUMBER"]
+except KeyError:
+    try:
+        VERSION = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], encoding="utf-8"
+        ).strip()
+    except Exception:
+        VERSION = "dev"
+
+CSV_FILE = "knowledgebase.csv"
+CONFIG_FILE = "config.json"
+TOOLTIPS_FILE = "ui_tooltips.json"
+COLUMNS = [
+    "category",
+    "faq_question",
+    "answer_text",
+    "stone_type",
+    "product_form",
+    "product_size",
+    "eigenschaft",
+    "anwendung",
+]
+
+CATEGORIES = [
+    "Produkt",
+    "Lieferung",
+    "Konstruktion",
+    "Sonstiges",
+]
+
+PROMPT_TEMPLATE = """
+System: Du bist Stone Knowledgebase Codex.
+Du bist ein gewissenhafter FAQ-Generator für telefonischen Kundensupport.
+Erstelle immer bis zu 5 FAQ-Einträge – auch wenn der Eingabetext keine Fragen enthält; formuliere dann selbst passende Fragen.
+Gib ausschließlich das folgende JSON-Format zurück (kein zusätzlicher Text!):
+
+{"entries":[{"category":"product|payment|delivery|installation|warranty","faq_question":"string","answer_text":"string","stone_type":"string","product_form":"string","product_size":"string (inkl. Einheit)","eigenschaft":"string","anwendung":"string"}]}
+
+User: Erstelle FAQ-Einträge aus diesem Rohtext (Deutsch):
+"""  # noqa: E501
+
+FALLBACK_HINT = "Bitte erstelle passende FAQ-Einträge, selbst wenn der Text kaum Informationen enthält.\n"
+
+
+def get_csv_path():
+    """Return CSV path from config or ask the user."""
+    if os.path.exists(CONFIG_FILE):
+        try:
+            with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                path = data.get("csv_path")
+                if path:
+                    return path
+        except Exception:
+            pass
+    path = filedialog.askopenfilename(filetypes=[("CSV", "*.csv")])
+    if not path:
+        path = CSV_FILE
+    try:
+        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+            json.dump({"csv_path": path}, f)
+    except Exception:
+        pass
+    return path
+
+
+def load_tooltips():
+    try:
+        with open(TOOLTIPS_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+class Tooltip:
+    """Simple hover tooltip."""
+
+    def __init__(self, widget, text):
+        self.widget = widget
+        self.text = text
+        self.tipwindow = None
+        widget.bind("<Enter>", self.show)
+        widget.bind("<Leave>", self.hide)
+
+    def show(self, _=None):
+        if self.tipwindow or not self.text:
+            return
+        x = self.widget.winfo_rootx() + 20
+        y = self.widget.winfo_rooty() + self.widget.winfo_height() + 1
+        self.tipwindow = tw = Toplevel(self.widget)
+        tw.wm_overrideredirect(True)
+        tw.wm_geometry(f"+{x}+{y}")
+        Label(
+            tw,
+            text=self.text,
+            background="#ffffe0",
+            relief="solid",
+            borderwidth=1,
+            font=("Segoe UI", 10),
+            justify="left",
+            wraplength=300,
+        ).pack(ipadx=1)
+
+    def hide(self, _=None):
+        if self.tipwindow:
+            self.tipwindow.destroy()
+            self.tipwindow = None
+
+
+class FAQEntry(BaseModel):
+    category: str
+    faq_question: str
+    answer_text: str
+    stone_type: str = ""
+    product_form: str = ""
+    product_size: str = ""
+    eigenschaft: str = ""
+    anwendung: str = ""
+
+    @validator("category")
+    def check_category(cls, v):
+        if v not in CATEGORIES:
+            raise ValueError("Ungültige Kategorie")
+        return v
+
+    @validator("product_size")
+    def ensure_unit(cls, v):
+        if v and not any(unit in v for unit in ["mm", "cm", "m"]):
+            if v.strip().isdigit():
+                return v + " mm"
+        return v
+
+
+def load_kb(path=CSV_FILE):
+    """Load the knowledge base from CSV or return an empty DataFrame."""
+    if os.path.exists(path):
+        df = pd.read_csv(path)
+        df = df.reindex(columns=COLUMNS)
+        df.fillna("", inplace=True)
+        return df
+    return pd.DataFrame(columns=COLUMNS)
+
+
+def save_kb(df, path=CSV_FILE):
+    """Persist the DataFrame back to the CSV file."""
+    df.reindex(columns=COLUMNS).to_csv(path, index=False)
+
+
+def cosine(a, b):
+    a = np.array(a)
+    b = np.array(b)
+    if not np.any(a) or not np.any(b):
+        return 0.0
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+
+
+def get_embedding(client, text):
+    resp = client.embeddings.create(input=[text], model="text-embedding-ada-002")
+    return resp.data[0].embedding
+
+
+def find_similar(df, question, client, existing_embeddings=None, top_n=3):
+    if df.empty or not question.strip() or not client:
+        return []
+    if existing_embeddings is None:
+        existing_embeddings = [
+            get_embedding(client, q) for q in df["faq_question"].fillna("")
+        ]
+    q_emb = get_embedding(client, question)
+    sims = [cosine(q_emb, emb) for emb in existing_embeddings]
+    idx = np.argsort(sims)[::-1][:top_n]
+    results = []
+    for i in idx:
+        if sims[i] > 0.7:
+            row = df.iloc[i]
+            results.append((sims[i], row))
+    return results
+
+
+LAST_RAW_CONTENT = ""
+
+
+def generate_suggestions(text, client):
+    """Return FAQ suggestions from OpenAI."""
+    global LAST_RAW_CONTENT
+    prompts = [PROMPT_TEMPLATE + text, PROMPT_TEMPLATE + FALLBACK_HINT + text]
+    LAST_RAW_CONTENT = ""
+    for prompt in prompts:
+        try:
+            resp = client.chat.completions.create(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": prompt}],
+                response_format={"type": "json_object"},
+                max_tokens=500,
+            )
+        except Exception as exc:
+            print(f"Error contacting OpenAI: {exc}", file=sys.stderr)
+            continue
+        content = resp.choices[0].message.content
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError:
+            print(content, file=sys.stderr)
+            LAST_RAW_CONTENT = content
+            continue
+        entries = data.get("entries") if isinstance(data, dict) else []
+        results = []
+        for e in entries:
+            try:
+                results.append(FAQEntry(**e).dict())
+            except Exception as exc:
+                print(f"Invalid entry skipped: {e} ({exc})", file=sys.stderr)
+        if results:
+            LAST_RAW_CONTENT = ""
+            return results
+    return []
+
+
+class KBManager:
+    def __init__(self, master):
+        self.master = master
+        master.title("Stone Knowledgebase Manager")
+        master.option_add("*Font", "Aptos 12")
+        self.style = tb.Style("flatly")
+        self.tooltips = load_tooltips()
+        self.csv_file = get_csv_path()
+        self.df = load_kb(self.csv_file).reset_index(drop=True)
+        if not os.path.exists(self.csv_file):
+            save_kb(self.df, self.csv_file)
+        self.lt = LanguageTool("de-DE")
+        self.api_key = os.environ.get("OPENAI_API_KEY", "")
+        self.client = OpenAI(api_key=self.api_key) if self.api_key else None
+        self.suggestions = []
+        self.current_suggestion_index = None
+        self.embeddings = []
+        self.trash = []
+        self.search_after_id = None
+        if self.client and not self.df.empty:
+            self.embeddings = [
+                get_embedding(self.client, q) for q in self.df["faq_question"]
+            ]
+
+        # frames for layout
+        toolbar = Frame(master)
+        self.form = Frame(master, highlightthickness=0)
+        table = Frame(master)
+        toolbar.grid(row=0, column=0, columnspan=2, sticky="ew")
+        self.form.grid(row=1, column=0, sticky="nsew", padx=5, pady=5)
+        table.grid(row=1, column=1, sticky="nsew", padx=5, pady=5)
+
+        master.columnconfigure(0, weight=1)
+        master.columnconfigure(1, weight=2)
+        master.rowconfigure(1, weight=1)
+        table.columnconfigure(0, weight=1)
+        table.rowconfigure(1, weight=1)
+        self.form.columnconfigure(1, weight=1)
+
+        self.entries = []
+        self.categories = CATEGORIES
+
+        fields = [
+            (
+                "Kategorie",
+                ttk.Combobox,
+                "category",
+                {"values": self.categories, "state": "readonly", "width": 37},
+            ),
+            ("Frage", Text, "faq_question", {"height": 2}),
+            ("Antwort", Text, "answer_text", {"height": 4}),
+            ("Steinart", Entry, "stone_type", {}),
+            ("Produktform", Entry, "product_form", {}),
+            ("Produktgröße", Entry, "product_size", {}),
+            ("Eigenschaft", Entry, "eigenschaft", {}),
+            ("Anwendung", Entry, "anwendung", {}),
+        ]
+
+        for i, (lbl, widget_cls, key, opts) in enumerate(fields):
+            Label(self.form, text=lbl).grid(row=i, column=0, sticky="e", pady=2)
+            if widget_cls is Text:
+                widget = widget_cls(self.form, width=60, **opts)
+                if key in {"faq_question", "answer_text"}:
+                    widget.bind(
+                        "<KeyRelease>", lambda e, w=widget: self.check_spelling(w)
+                    )
+            elif widget_cls is ttk.Combobox:
+                widget = widget_cls(self.form, **opts)
+            else:
+                widget = widget_cls(self.form, width=60)
+            widget.grid(row=i, column=1, padx=5, pady=2, sticky="ew")
+            Tooltip(widget, self.tooltips.get(key, ""))
+            self.entries.append(widget)
+
+        self.form.columnconfigure(1, weight=1)
+
+        base = len(fields)
+        Label(self.form, text="Text für KI-Vorschläge").grid(row=base, column=0, sticky="ne")
+        self.source_text = Text(self.form, width=60, height=6)
+        self.source_text.grid(row=base, column=1, padx=5, pady=2, sticky="ew")
+        Tooltip(self.source_text, self.tooltips.get("source", ""))
+        btn_row = base + 1
+        self.gen_button = tb.Button(
+            self.form,
+            text="🧠 Vorschläge generieren",
+            command=self.generate_suggestions,
+            bootstyle="primary",
+        )
+        self.gen_button.grid(row=btn_row, column=0, pady=(5, 0), sticky="w")
+        Tooltip(self.gen_button, "KI analysiert den Text und erstellt Vorschläge")
+        self.ai_message_var = StringVar()
+        self.ai_message_label = Label(
+            self.form, textvariable=self.ai_message_var, foreground="red"
+        )
+        self.ai_message_label.grid(row=btn_row, column=1, sticky="w")
+        btn_row += 1
+        self.sim_button = tb.Button(
+            self.form,
+            text="🔍 Ähnliche Fragen",
+            command=self.check_similar,
+        )
+        self.sim_button.grid(row=btn_row, column=0, sticky="e", pady=5, padx=2)
+        Tooltip(self.sim_button, "Suche in der Tabelle nach ähnlichen Fragen")
+        self.save_button = tb.Button(
+            self.form,
+            text="💾 Speichern",
+            command=self.save_entry,
+            bootstyle="success",
+        )
+        self.save_button.grid(row=btn_row, column=1, sticky="w", pady=5, padx=2)
+        Tooltip(self.save_button, "Eintrag speichern")
+        btn_row += 1
+        manage = Frame(self.form)
+        manage.grid(row=btn_row, column=0, columnspan=2, pady=2)
+        self.load_button = tb.Button(
+            manage, text="📂 Laden", command=self.load_entry
+        )
+        self.load_button.pack(side="left", padx=2)
+        Tooltip(self.load_button, "Markierten Eintrag bearbeiten")
+        self.delete_button = tb.Button(
+            manage,
+            text="🗑 Löschen",
+            command=self.delete_entry,
+            bootstyle="danger",
+        )
+        self.delete_button.pack(side="left", padx=2)
+        Tooltip(self.delete_button, "Markierten Eintrag löschen")
+        self.undo_button = tb.Button(
+            manage, text="↩️ Rückgängig", command=self.undo_delete
+        )
+        self.undo_button.pack(side="left", padx=2)
+        Tooltip(self.undo_button, "Letzten Löschvorgang zurücknehmen")
+        self.new_button = tb.Button(manage, text="➕ Neu", command=self.clear_form)
+        self.new_button.pack(side="left", padx=2)
+        Tooltip(self.new_button, "Formular leeren")
+        btn_row += 1
+        self.suggestion_box = Listbox(self.form)
+        self.suggestion_box.grid(
+            row=btn_row,
+            column=0,
+            columnspan=2,
+            padx=5,
+            pady=5,
+            sticky="nsew",
+        )
+        self.form.rowconfigure(btn_row, weight=1)
+        self.suggestion_box.bind("<Double-1>", lambda e: self.load_suggestion())
+        self.suggestion_box.bind("<ButtonRelease-1>", lambda e: self.load_suggestion())
+        btn_row += 1
+        del_btn = tb.Button(
+            self.form,
+            text="🗑 Vorschlag löschen",
+            command=self.delete_suggestion,
+            bootstyle="danger",
+        )
+        del_btn.grid(row=btn_row, column=0, columnspan=2, pady=2)
+        Tooltip(del_btn, "Entfernt den gewählten Vorschlag")
+        btn_row += 1
+        key_btn = tb.Button(
+            self.form,
+            text="🔑 API-Key eingeben",
+            command=self.set_api_key,
+            bootstyle="secondary",
+        )
+        key_btn.grid(row=btn_row, column=0, columnspan=2, pady=2)
+        Tooltip(key_btn, "OpenAI API-Key festlegen")
+
+        filter_frame = Frame(table)
+        filter_frame.grid(row=0, column=0, columnspan=2, sticky="ew", pady=(0, 4))
+        Label(filter_frame, text="Filter:").pack(side="left")
+        self.filter_text = StringVar()
+        self.filter_text.trace_add("write", self.on_filter_change)
+        self.filter_entry = ttk.Entry(filter_frame, textvariable=self.filter_text)
+        self.filter_entry.pack(side="left", fill="x", expand=True)
+        reset_btn = tb.Button(filter_frame, text="Reset", command=self.reset_filter)
+        reset_btn.pack(side="left")
+        Tooltip(reset_btn, "Filter zurücksetzen")
+        self.progress = ttk.Progressbar(filter_frame, mode="indeterminate", length=80)
+
+        self.tree = ttk.Treeview(table, columns=COLUMNS, show="headings")
+        self.sort_state = {c: False for c in COLUMNS}
+        for col in COLUMNS:
+            self.tree.heading(
+                col, text=col, command=lambda c=col: self.sort_by_column(c)
+            )
+            self.tree.column(col, width=120, anchor="w")
+        self.tree_scroll = Scrollbar(table, orient="vertical", command=self.tree.yview)
+        self.tree.configure(yscrollcommand=self.tree_scroll.set)
+        self.tree.grid(row=1, column=0, sticky="nsew")
+        self.tree_scroll.grid(row=1, column=1, sticky="ns")
+        self.tree.bind("<<TreeviewSelect>>", lambda e: None)
+        self.tree.bind("<Double-1>", lambda e: self.load_entry())
+        self.tree.tag_configure("match", background="#ffff99")
+        self.row_menu = Menu(self.tree, tearoff=0)
+        self.row_menu.add_command(label="Kopieren", command=self.copy_row)
+        self.row_menu.add_command(label="Löschen", command=self.delete_entry)
+        self.empty_menu = Menu(self.tree, tearoff=0)
+        self.empty_menu.add_command(
+            label="Neuen Eintrag einfügen", command=self.clear_form
+        )
+        self.tree.bind("<Button-3>", self.show_context_menu)
+
+        self.master.bind("<Escape>", lambda e: self.on_escape())
+
+        self.refresh_tree()
+        self.edit_index = None
+
+        self.message_var = StringVar()
+        self.message_label = Label(master, textvariable=self.message_var)
+        self.message_label.grid(row=2, column=0, sticky="w", padx=5, pady=2)
+        Label(master, text=f"Version {VERSION}").grid(
+            row=2, column=1, sticky="e", padx=5, pady=2
+        )
+        master.bind_all("<Control-s>", lambda e: self.save_entry())
+
+    def refresh_tree(self):
+        """Fill the treeview with all current rows."""
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+        max_lines = 1
+        for _, row in self.df.iterrows():
+            values = []
+            for col in COLUMNS:
+                text = str(row[col])
+                wrapped = textwrap.fill(text, 30)
+                values.append(wrapped)
+                max_lines = max(max_lines, wrapped.count("\n") + 1)
+            self.tree.insert("", "end", values=values)
+        ttk.Style().configure("Treeview", rowheight=20 * max_lines)
+
+    def apply_filter(self):
+        term = self.filter_text.get().strip()
+        if not term:
+            self.refresh_tree()
+            return
+        show_id = self.master.after(200, self.start_progress)
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+        mask = self.df.apply(
+            lambda r: term.lower() in " ".join(str(v).lower() for v in r.values),
+            axis=1,
+        )
+        for _, row in self.df[mask].iterrows():
+            values = [textwrap.fill(str(row[c]), 30) for c in COLUMNS]
+            self.tree.insert("", "end", values=values, tags=("match",))
+        self.master.after_cancel(show_id)
+        self.stop_progress()
+
+    def reset_filter(self):
+        self.filter_text.set("")
+        self.refresh_tree()
+
+    def sort_by_column(self, col):
+        """Sort the table by the given column."""
+        self.sort_state[col] = not self.sort_state[col]
+        self.df.sort_values(
+            col, ascending=not self.sort_state[col], inplace=True, ignore_index=True
+        )
+        self.refresh_tree()
+
+    def refresh_suggestion_box(self):
+        """Update the suggestion list with current items."""
+        self.suggestion_box.delete(0, END)
+        for i, item in enumerate(self.suggestions, start=1):
+            question = item.get("faq_question", "")
+            self.suggestion_box.insert(END, f"{i}. {question}")
+            bg = "#f7f7f7" if i % 2 else "white"
+            self.suggestion_box.itemconfig(i - 1, bg=bg)
+
+    def animate_scroll_to(self, index, steps=10, delay=20):
+        """Scroll the treeview to the given row with a short animation."""
+        items = self.tree.get_children()
+        if not items or index >= len(items):
+            return
+        target = index / max(1, len(items))
+        start = self.tree.yview()[0]
+        delta = (target - start) / steps
+
+        for step in range(steps):
+            pos = start + delta * (step + 1)
+            self.master.after(delay * step, lambda p=pos: self.tree.yview_moveto(p))
+
+    def highlight_row(self, index):
+        items = self.tree.get_children()
+        if index < len(items):
+            iid = items[index]
+            self.tree.selection_set(iid)
+            self.tree.focus(iid)
+            self.animate_scroll_to(index)
+
+    def toggle_theme(self):
+        self.dark = not self.dark
+        theme = "darkly" if self.dark else "flatly"
+        self.style.theme_use(theme)
+
+    def show_context_menu(self, event):
+        rowid = self.tree.identify_row(event.y)
+        if rowid:
+            self.tree.selection_set(rowid)
+            self.row_menu.tk_popup(event.x_root, event.y_root)
+        else:
+            self.empty_menu.tk_popup(event.x_root, event.y_root)
+
+    def copy_row(self):
+        sel = self.tree.selection()
+        if not sel:
+            return
+        idx = self.tree.index(sel[0])
+        row = self.df.iloc[idx]
+        text = f"{row['faq_question']}\n{row['answer_text']}"
+        self.master.clipboard_clear()
+        self.master.clipboard_append(text)
+
+    def start_progress(self):
+        self.progress.pack(side="left")
+        self.progress.start(10)
+
+    def stop_progress(self):
+        self.progress.stop()
+        self.progress.pack_forget()
+
+    def disable_inputs(self):
+        widgets = [
+            self.source_text,
+            self.sim_button,
+            self.save_button,
+            self.load_button,
+            self.delete_button,
+            self.undo_button,
+            self.new_button,
+        ]
+        for widget in self.entries + widgets:
+            try:
+                widget.configure(state="disabled")
+            except Exception:
+                pass
+        self.gen_button.configure(state="disabled")
+
+    def enable_inputs(self):
+        widgets = [
+            self.source_text,
+            self.sim_button,
+            self.save_button,
+            self.load_button,
+            self.delete_button,
+            self.undo_button,
+            self.new_button,
+        ]
+        for widget in self.entries + widgets:
+            try:
+                widget.configure(state="normal")
+            except Exception:
+                pass
+        self.gen_button.configure(state="normal")
+
+    def start_ai_animation(self):
+        self.ai_running = True
+        self.ai_dots = "..."
+
+        def animate():
+            if not self.ai_running:
+                return
+            self.ai_message_var.set(f"KI arbeitet {self.ai_dots}")
+            self.ai_dots = self.ai_dots[:-1] if len(self.ai_dots) > 1 else "..."
+            self.master.after(500, animate)
+
+        animate()
+
+    def stop_ai_animation(self):
+        self.ai_running = False
+        self.ai_message_var.set("")
+
+    def show_message(self, message, error=False, success=False, info=False):
+        """Display a status message and toast."""
+
+        self.message_var.set(message)
+        if error:
+            color = "#dc3545"
+        elif success:
+            color = "#28a745"
+        elif info:
+            color = "#17a2b8"
+        else:
+            color = "black"
+        self.message_label.configure(foreground=color)
+        if error or success or info:
+            ToastNotification(
+                title="",
+                message=message,
+                duration=4000,
+                bootstyle="secondary",
+                position=(0, 0, "se"),
+            ).show_toast()
+        self.master.after(5000, lambda: self.message_var.set(""))
+
+    def highlight_form(self):
+        self.form.configure(highlightbackground="#FFA64D", highlightthickness=2)
+
+    def clear_highlight(self):
+        self.form.configure(highlightthickness=0)
+
+    def on_escape(self, _=None):
+        self.clear_highlight()
+        self.filter_text.set("")
+
+    def on_filter_change(self, *_):
+        if self.search_after_id:
+            self.master.after_cancel(self.search_after_id)
+        self.search_after_id = self.master.after(300, self.apply_filter)
+
+    def clear_form(self):
+        """Clear all entry widgets and reset edit mode."""
+        for widget in self.entries:
+            if isinstance(widget, Text):
+                widget.delete("1.0", END)
+            elif isinstance(widget, ttk.Combobox):
+                widget.set("")
+            else:
+                widget.delete(0, END)
+        self.edit_index = None
+        self.current_suggestion_index = None
+        self.clear_highlight()
+
+    def load_entry(self):
+        """Load the selected row from the table into the form for editing."""
+        selection = self.tree.selection()
+        if not selection:
+            self.show_message("Bitte zuerst einen Eintrag auswählen.", error=True)
+            return
+        index = self.tree.index(selection[0])
+        row = self.df.iloc[index]
+        for widget, col in zip(self.entries, COLUMNS):
+            value = str(row[col]) if pd.notna(row[col]) else ""
+            if isinstance(widget, Text):
+                widget.delete("1.0", END)
+                widget.insert("1.0", value)
+            elif isinstance(widget, ttk.Combobox):
+                widget.set(value)
+            else:
+                widget.delete(0, END)
+                widget.insert(0, value)
+        self.edit_index = index
+        self.highlight_form()
+
+    def delete_entry(self):
+        """Delete the selected row from the table and CSV."""
+        selection = self.tree.selection()
+        if not selection:
+            self.show_message("Bitte zuerst einen Eintrag auswählen.", error=True)
+            return
+        index = self.tree.index(selection[0])
+        self.trash.append(self.df.iloc[index].to_dict())
+        self.df = self.df.drop(self.df.index[index]).reset_index(drop=True)
+        save_kb(self.df, self.csv_file)
+        self.refresh_tree()
+        self.edit_index = None
+        self.show_message("Eintrag gelöscht.", success=True)
+
+    def undo_delete(self):
+        if not self.trash:
+            self.show_message("Kein Eintrag zum Wiederherstellen.", error=True)
+            return
+        row = self.trash.pop()
+        self.df.loc[len(self.df)] = row
+        save_kb(self.df, self.csv_file)
+        self.refresh_tree()
+        self.show_message("Eintrag wiederhergestellt.", success=True)
+
+    def check_spelling(self, widget):
+        text = widget.get("1.0", END)
+        widget.tag_delete("misspell")
+        widget.tag_configure("misspell", underline=True, foreground="#d9534f")
+        try:
+            matches = self.lt.check(text)
+        except Exception:
+            matches = []
+        for m in matches:
+            start = f"1.0+{m.offset}c"
+            end = f"1.0+{m.offset + m.errorLength}c"
+            widget.tag_add("misspell", start, end)
+
+    def get_entry_values(self):
+        values = []
+        for widget in self.entries:
+            if isinstance(widget, Text):
+                values.append(widget.get("1.0", END).strip())
+            elif isinstance(widget, ttk.Combobox):
+                values.append(widget.get().strip())
+            else:
+                values.append(widget.get().strip())
+        return dict(zip(COLUMNS, values))
+
+    def set_api_key(self):
+        """Prompt the user for an OpenAI API key."""
+        key = simpledialog.askstring("API-Key", "OpenAI API-Key eingeben:", show="*")
+        if key:
+            self.api_key = key
+            self.client = OpenAI(api_key=key)
+
+    def suggest_improvement(self, text):
+        """Ask OpenAI for improvement hints for the given text."""
+        if not self.client:
+            return ""
+        prompt = (
+            "Der folgende Text reicht nicht aus, um vollst\u00e4ndige FAQ-Vorschl\u00e4ge zu erzeugen. "
+            "Gib in einem Satz an, welche zus\u00e4tzlichen Informationen sinnvoll w\u00e4ren:"
+        )
+        try:
+            resp = self.client.chat.completions.create(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": prompt + "\n" + text}],
+                max_tokens=60,
+            )
+            return resp.choices[0].message.content.strip()
+        except Exception:
+            return ""
+
+    def generate_suggestions(self):
+        """Generate suggestions via OpenAI and update the list."""
+        if not self.client:
+            self.set_api_key()
+            if not self.client:
+                return
+        text = self.source_text.get("1.0", END).strip()
+        self.disable_inputs()
+        self.start_ai_animation()
+        new_entries = generate_suggestions(text, self.client)
+        self.stop_ai_animation()
+        self.enable_inputs()
+        if not new_entries:
+            self.ai_message_var.set("Keine geeigneten Vorschläge gefunden.")
+            return
+        self.ai_message_var.set("")
+        self.suggestions.extend(new_entries)
+        self.refresh_suggestion_box()
+
+    def load_suggestion(self):
+        """Load the selected suggestion into the form."""
+        sel = self.suggestion_box.curselection()
+        if not sel:
+            return
+        index = sel[0]
+        suggestion = self.suggestions[index]
+        self.current_suggestion_index = index
+        try:
+            data = FAQEntry(**suggestion).dict()
+        except Exception:
+            data = suggestion
+        for widget, col in zip(self.entries, COLUMNS):
+            val = data.get(col, "")
+            if isinstance(widget, Text):
+                widget.delete("1.0", END)
+                widget.insert("1.0", val)
+            elif isinstance(widget, ttk.Combobox):
+                widget.set(val)
+            else:
+                widget.delete(0, END)
+                widget.insert(0, val)
+        self.highlight_form()
+
+    def delete_suggestion(self):
+        """Remove the selected suggestion from the list."""
+        sel = self.suggestion_box.curselection()
+        if not sel:
+            return
+        idx = sel[0]
+        self.suggestions.pop(idx)
+        if self.current_suggestion_index == idx:
+            self.current_suggestion_index = None
+        self.refresh_suggestion_box()
+
+    def check_similar(self):
+        data = self.get_entry_values()
+        if data is None:
+            return
+        question = data["faq_question"]
+        sims = find_similar(self.df, question, self.client, self.embeddings)
+        if sims:
+            self.highlight_row(sims[0][1].name)
+            self.show_message("Ähnliche Frage gefunden.")
+        else:
+            self.show_message("Keine ähnlichen Fragen gefunden.")
+
+    def save_entry(self):
+        data = self.get_entry_values()
+        if not data:
+            return
+        if not data["faq_question"] or not data["answer_text"]:
+            self.show_message("Antwort darf nicht leer sein", error=True)
+            return
+        if data["category"] not in CATEGORIES:
+            self.show_message("Ungültige Kategorie", error=True)
+            return
+        if (
+            self.entries[1].tag_ranges("misspell")
+            or self.entries[2].tag_ranges("misspell")
+        ):
+            self.show_message("Rechtschreibfehler vorhanden", error=True)
+            return
+        for k in COLUMNS:
+            if k not in {"faq_question", "answer_text"} and not data[k]:
+                data[k] = "Keine Angabe"
+        try:
+            new_row = FAQEntry(**data).dict()
+        except Exception as exc:
+            self.show_message(f"Ungültige Eingaben: {exc}", error=True)
+            return
+        if self.edit_index is None:
+            row_index = len(self.df)
+            self.df.loc[row_index] = new_row
+        else:
+            row_index = self.edit_index
+            for col, val in new_row.items():
+                self.df.at[row_index, col] = val
+            self.edit_index = None
+        save_kb(self.df, self.csv_file)
+        self.show_message("Eintrag wurde gespeichert.", success=True)
+        self.refresh_tree()
+        self.highlight_row(row_index)
+        self.clear_form()
+        self.clear_highlight()
+        if self.current_suggestion_index is not None:
+            self.suggestions.pop(self.current_suggestion_index)
+            self.refresh_suggestion_box()
+            self.current_suggestion_index = None
+
+
+if __name__ == "__main__":
+    root = tb.Window(themename="flatly")
+    app = KBManager(root)
+    root.mainloop()

--- a/knowledgebase.csv
+++ b/knowledgebase.csv
@@ -1,0 +1,1 @@
+category,faq_question,answer_text,stone_type,product_form,product_size,eigenschaft,anwendung

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pandas
+numpy
+pydantic
+openai>=1.0.0
+language_tool_python>=2.7
+flake8
+ttkbootstrap

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/tests/test_border_toggle.py
+++ b/tests/test_border_toggle.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import tkinter as tk
+import pandas as pd
+import pytest
+from ttkbootstrap import Window
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from kb_manager import KBManager, COLUMNS, save_kb  # noqa: E402
+
+
+def display_available():
+    try:
+        root = tk.Tk()
+        root.destroy()
+        return True
+    except tk.TclError:
+        return False
+
+
+@pytest.mark.skipif(not display_available(), reason="requires display")
+def test_border_toggle(monkeypatch, tmp_path):
+    monkeypatch.setattr('language_tool_python.LanguageTool', lambda *_: None)
+    csv_path = tmp_path / 'kb.csv'
+    df = pd.DataFrame(columns=COLUMNS)
+    save_kb(df, csv_path)
+    root = Window(themename='flatly')
+    app = KBManager(root)
+    app.csv_file = str(csv_path)
+    app.df = df
+    app.refresh_tree()
+
+    sug = {
+        'category': 'Produkt',
+        'faq_question': 'Q',
+        'answer_text': 'A',
+        'stone_type': '',
+        'product_form': '',
+        'product_size': '',
+        'eigenschaft': '',
+        'anwendung': '',
+    }
+    app.suggestions = [sug]
+    app.refresh_suggestion_box()
+    app.suggestion_box.selection_set(0)
+    app.load_suggestion()
+    assert int(app.form.cget('highlightthickness')) == 2
+    app.save_entry()
+    assert int(app.form.cget('highlightthickness')) == 0
+    root.destroy()

--- a/tests/test_category_validation.py
+++ b/tests/test_category_validation.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import tkinter as tk
+import pytest
+from ttkbootstrap import Window
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from kb_manager import KBManager  # noqa: E402
+
+
+def display_available():
+    try:
+        root = tk.Tk()
+        root.destroy()
+        return True
+    except tk.TclError:
+        return False
+
+
+@pytest.mark.skipif(not display_available(), reason="requires display")
+def test_category_validation(monkeypatch):
+    monkeypatch.setattr('language_tool_python.LanguageTool', lambda *_: None)
+    root = Window(themename="flatly")
+    app = KBManager(root)
+    app.entries[0].set('Falsch')
+    app.entries[1].insert('1.0', 'Frage?')
+    app.entries[2].insert('1.0', 'Antwort')
+    app.save_entry()
+    assert 'Ungültige Kategorie' in app.message_var.get()
+    root.destroy()

--- a/tests/test_edit_border.py
+++ b/tests/test_edit_border.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import pandas as pd
+import tkinter as tk
+import pytest
+from ttkbootstrap import Window
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from kb_manager import KBManager, COLUMNS, save_kb  # noqa: E402
+
+
+def display_available():
+    try:
+        root = tk.Tk()
+        root.destroy()
+        return True
+    except tk.TclError:
+        return False
+
+
+@pytest.mark.skipif(not display_available(), reason="requires display")
+def test_edit_border_escape(tmp_path):
+    csv_path = tmp_path / "kb.csv"
+    df = pd.DataFrame([{c: "x" for c in COLUMNS}])
+    save_kb(df, csv_path)
+    root = Window(themename="flatly")
+    app = KBManager(root)
+    app.csv_file = str(csv_path)
+    app.df = df
+    app.refresh_tree()
+    app.tree.selection_set(app.tree.get_children()[0])
+    app.load_entry()
+    assert int(app.form.cget("highlightthickness")) == 2
+    app.on_escape()
+    assert int(app.form.cget("highlightthickness")) == 0
+    root.destroy()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,57 @@
+import json
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from kb_manager import generate_suggestions, COLUMNS, FAQEntry  # noqa: E402
+
+
+class DummyResp:
+    def __init__(self, content):
+        self.choices = [type('obj', (), {'message': type('obj', (), {'content': content})})]
+
+
+class DummyCreate:
+    def __init__(self, contents):
+        self.contents = contents
+        self.index = 0
+
+    def create(self, **kwargs):
+        content = self.contents[self.index]
+        self.index += 1
+        return DummyResp(content)
+
+
+class DummyChat:
+    def __init__(self, contents):
+        self.completions = DummyCreate(contents)
+
+
+class DummyClient:
+    def __init__(self, contents):
+        self.chat = DummyChat(contents)
+
+
+def test_generate_length_and_schema():
+    data = {
+        "entries": [
+            {
+                "category": "Produkt",
+                "faq_question": "Welche Steine sind hart?",
+                "answer_text": "Alle Granitsteine sind sehr hart.",
+                "stone_type": "Granit",
+                "product_form": "Block",
+                "product_size": "10 cm",
+                "eigenschaft": "sehr hart",
+                "anwendung": "Gartenbau",
+            }
+        ]
+    }
+    client = DummyClient([json.dumps(data)])
+    entries = generate_suggestions("Stein ist hart", client)
+    assert len(entries) >= 1
+    for entry in entries:
+        FAQEntry(**entry)
+        for key in COLUMNS:
+            assert key in entry

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,52 @@
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))  # noqa: E402
+
+from kb_manager import KBManager, load_kb, save_kb  # noqa: E402
+from ttkbootstrap import Window  # noqa: E402
+import tkinter as tk  # noqa: E402
+import pytest  # noqa: E402
+
+
+def display_available():
+    try:
+        root = tk.Tk()
+        root.destroy()
+        return True
+    except tk.TclError:
+        return False
+
+
+def setup_module(module):
+    df = load_kb()
+    if df.empty:
+        df.loc[0] = {
+            'category': 'Produkt',
+            'faq_question': 'Welche Steine sind hart?',
+            'answer_text': 'Alle Granitsteine sind hart.',
+            'stone_type': 'Granit',
+            'product_form': 'Block',
+            'product_size': '10 cm',
+            'eigenschaft': 'hart',
+            'anwendung': 'Garten',
+        }
+        save_kb(df)
+
+
+@pytest.mark.skipif(not display_available(), reason="requires display")
+def test_live_search():
+    root = Window(themename="flatly")
+    app = KBManager(root)
+    app.filter_text.set('Steine')
+    app.apply_filter()
+    assert len(app.tree.get_children()) >= 1
+    root.destroy()
+
+
+@pytest.mark.skipif(not display_available(), reason="requires display")
+def test_context_menu_entries():
+    root = Window(themename="flatly")
+    app = KBManager(root)
+    labels = [app.row_menu.entrycget(i, 'label') for i in range(app.row_menu.index('end') + 1)]
+    assert {'Löschen', 'Kopieren'} <= set(labels)
+    root.destroy()

--- a/tests/test_spellcheck.py
+++ b/tests/test_spellcheck.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import tkinter as tk
+import pytest
+from ttkbootstrap import Window
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from kb_manager import KBManager  # noqa: E402
+
+
+def display_available():
+    try:
+        root = tk.Tk()
+        root.destroy()
+        return True
+    except tk.TclError:
+        return False
+
+
+@pytest.mark.skipif(not display_available(), reason="requires display")
+def test_spellcheck_highlight(monkeypatch):
+    class DummyLT:
+        def check(self, text):
+            return [type('obj', (), {'offset': 5, 'errorLength': 4})]
+
+    monkeypatch.setattr('language_tool_python.LanguageTool', lambda *_: DummyLT())
+    root = Window(themename="flatly")
+    app = KBManager(root)
+    widget = app.entries[1]  # faq_question Text widget
+    widget.insert('1.0', 'Hallo testt')
+    app.check_spelling(widget)
+    assert widget.tag_ranges('misspell')
+    root.destroy()

--- a/tests/test_suggestion_flow.py
+++ b/tests/test_suggestion_flow.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import pandas as pd
+import tkinter as tk
+import pytest
+from ttkbootstrap import Window
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from kb_manager import KBManager, COLUMNS, save_kb  # noqa: E402
+
+
+def display_available():
+    try:
+        root = tk.Tk()
+        root.destroy()
+        return True
+    except tk.TclError:
+        return False
+
+
+@pytest.mark.skipif(not display_available(), reason="requires display")
+def test_suggestion_save_flow(tmp_path):
+    csv_path = tmp_path / "kb.csv"
+    df = pd.DataFrame(columns=COLUMNS)
+    save_kb(df, csv_path)
+    root = Window(themename="flatly")
+    app = KBManager(root)
+    app.csv_file = str(csv_path)
+    app.df = df
+    app.refresh_tree()
+
+    suggestion = {
+        "category": "Produkt",
+        "faq_question": "Q1",
+        "answer_text": "A1",
+        "stone_type": "",
+        "product_form": "",
+        "product_size": "",
+        "eigenschaft": "",
+        "anwendung": "",
+    }
+    app.suggestions = [suggestion]
+    app.refresh_suggestion_box()
+    app.suggestion_box.selection_set(0)
+    app.load_suggestion()
+    app.save_entry()
+    assert not app.suggestions
+    root.destroy()

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -1,0 +1,68 @@
+import json
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import kb_manager  # noqa: E402
+
+
+class DummyResp:
+    def __init__(self, content):
+        self.choices = [
+            type("obj", (), {"message": type("obj", (), {"content": content})})
+        ]
+
+
+class DummyCreate:
+    def __init__(self, contents):
+        self.contents = contents
+        self.index = 0
+
+    def create(self, **kwargs):
+        content = self.contents[self.index]
+        self.index += 1
+        return DummyResp(content)
+
+
+class DummyChat:
+    def __init__(self, contents):
+        self.completions = DummyCreate(contents)
+
+
+class DummyClient:
+    def __init__(self, contents):
+        self.chat = DummyChat(contents)
+
+
+def test_generate_retries():
+    bad = "{invalid json"
+    good = json.dumps(
+        {
+            "entries": [
+                {
+                    "category": "Produkt",
+                    "faq_question": "Q",
+                    "answer_text": "A",
+                    "stone_type": "",
+                    "product_form": "",
+                    "product_size": "10 cm",
+                    "eigenschaft": "",
+                    "anwendung": "",
+                }
+            ]
+        }
+    )
+    client = DummyClient([bad, good])
+    entries = kb_manager.generate_suggestions("text", client)
+    assert len(entries) == 1
+    assert kb_manager.LAST_RAW_CONTENT == ""
+
+
+def test_generate_all_fail():
+    bad1 = "{invalid"
+    bad2 = "{still bad"
+    client = DummyClient([bad1, bad2])
+    entries = kb_manager.generate_suggestions("text", client)
+    assert entries == []
+    assert kb_manager.LAST_RAW_CONTENT == bad2

--- a/ui_tooltips.json
+++ b/ui_tooltips.json
@@ -1,0 +1,11 @@
+{
+  "category": "Kategorie des Eintrags, z.B. product, payment, delivery, installation oder warranty",
+  "faq_question": "Kundenfrage, die vom Voice Agent beantwortet werden soll",
+  "answer_text": "Vollständige Antwort, die Lisa 2 sprechen wird",
+  "stone_type": "Steinart wie Granit, Jurakalk usw.",
+  "product_form": "Form des Produkts, z.B. Splitt oder Platte",
+  "product_size": "Größe inklusive Einheit, etwa 8/16 mm oder 30 cm",
+  "eigenschaft": "Besondere Eigenschaft wie frostbeständig",
+  "anwendung": "Typischer Einsatzbereich"
+  ,"source": "Freitext zur Erzeugung von KI-Vorschlägen"
+}


### PR DESCRIPTION
## Summary
- add robust fallback in `generate_suggestions`
- show inline message when no AI suggestions are found
- expose last raw API response for debugging
- test retry logic with malformed JSON
- upgrade message handling, button layout and progress indicator
- modernize layout with single-column form and emoji buttons
- highlight search matches and add Copy context menu option

## Testing
- `pip install -r requirements.txt`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687cf9fafeb0832e95ba6948bc3e2b71